### PR TITLE
resolve Markdown syntax issue that may make some viewers hang

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ssh-askpass (for Mac OS X)
 
-Author: Mark Carver
-Created: 2011-09-14
+Author: Mark Carver  
+Created: 2011-09-14  
 Copyright (c) 2011 Beyond Eden Development, LLC. All rights reserved.
 
 Based off script from author: Joseph Mocker, Sun Microsystems


### PR DESCRIPTION
Markdown syntax issue- fenced code blocks must have triple tick on separate line. Not doing this causes many Markdown viewers to hang/crash on OS X, such as Multimarkdown Composer or Marked.
